### PR TITLE
Disable image url encoding

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,7 +56,7 @@ module.exports = (env, argv) => {
           test: /\.(gif|png|jpg|jpeg)$/,
           loader: "url-loader",
           options: {
-            limit: 8192,
+            limit: false,
           },
         },
         {


### PR DESCRIPTION
Will failed the current git actions. This is required for dynamic host to work